### PR TITLE
Removed Private Color in styles.xml and replaced with textColorPrimary

### DIFF
--- a/Controls/src/main/res/values/styles.xml
+++ b/Controls/src/main/res/values/styles.xml
@@ -15,7 +15,7 @@
         <item name="android:colorBackground">@android:color/black</item>
         <item name="android:windowAnimationStyle">@null</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="wallpaperTextColor">@*android:color/primary_text_material_dark</item>
+        <item name="wallpaperTextColor">?android:attr/textColorPrimary</item>
     </style>
 
     <style name="TextAppearance.Control" parent="@android:style/TextAppearance">


### PR DESCRIPTION
As mentioned #107 there is an issue users are facing with the app controls not working. I believe I have found the issue and have corrected it.  

This is the place where the layout inflation was failing


```xml
<TextView
            android:id="@+id/onboarding_text"
            ...
            android:textColor="?attr/wallpaperTextColor"
            android:textSize="16sp"/>
        <ImageView
            android:id="@+id/dismiss"
            android:layout_width="40dp"
            ...
            android:tint="?attr/wallpaperTextColor"
            ...
            tools:ignore="UseAppTint" />
```



The line ``?attr/wallpaperTextColor`` was causing the failure. This attribute is defined in the ``attrs.xml`` but the true problem is in the ``styles.xml``, which contains a private reference that the inflater did not like. I think I have found a non private android attribute that will accomplish the same task. This fixed the issue for me
            