### PR TITLE
Fix HyperOS xposed hooking

### DIFF
--- a/app/src/main/java/com/kieronquinn/app/classicpowermenu/components/xposed/Xposed.kt
+++ b/app/src/main/java/com/kieronquinn/app/classicpowermenu/components/xposed/Xposed.kt
@@ -14,7 +14,6 @@ import com.kieronquinn.app.classicpowermenu.service.globalactions.GlobalActionsS
 import com.kieronquinn.app.classicpowermenu.utils.extensions.SystemProperties_getString
 import de.robv.android.xposed.*
 import de.robv.android.xposed.callbacks.XC_LoadPackage
-import java.lang.reflect.Method
 
 class Xposed: IXposedHookLoadPackage, ServiceConnection {
 
@@ -60,6 +59,7 @@ class Xposed: IXposedHookLoadPackage, ServiceConnection {
 
     private fun hookSystemUI(lpparam: XC_LoadPackage.LoadPackageParam){
         when {
+            miuiVersion >= 816 -> hookAospSystemUI(lpparam)
             miuiVersion >= 125 -> hookMiuiSystemUI(lpparam)
             oneuiVersion >= 90000 -> hookOneUISystemUI(lpparam)
             else -> hookAospSystemUI(lpparam)


### PR DESCRIPTION
This allows the xposed hooking to work on HyperOS.
Since there were some changed and the MIUI hooking didnt work anymore, I tried to find a fix for it for two hours when I just tried to use the AOSP hooking method, which apparently is working.
So with this I dont need to use the accessibility method anymore :)