### PR TITLE
Hyperos support

### DIFF
--- a/app/src/main/java/com/kieronquinn/app/classicpowermenu/components/xposed/Xposed.kt
+++ b/app/src/main/java/com/kieronquinn/app/classicpowermenu/components/xposed/Xposed.kt
@@ -14,7 +14,6 @@ import com.kieronquinn.app.classicpowermenu.service.globalactions.GlobalActionsS
 import com.kieronquinn.app.classicpowermenu.utils.extensions.SystemProperties_getString
 import de.robv.android.xposed.*
 import de.robv.android.xposed.callbacks.XC_LoadPackage
-import java.lang.reflect.Method
 
 class Xposed: IXposedHookLoadPackage, ServiceConnection {
 
@@ -60,6 +59,7 @@ class Xposed: IXposedHookLoadPackage, ServiceConnection {
 
     private fun hookSystemUI(lpparam: XC_LoadPackage.LoadPackageParam){
         when {
+            miuiVersion >= 816 -> hookAospSystemUI(lpparam)
             miuiVersion >= 125 -> hookMiuiSystemUI(lpparam)
             oneuiVersion >= 90000 -> hookOneUISystemUI(lpparam)
             else -> hookAospSystemUI(lpparam)

--- a/app/src/main/java/com/kieronquinn/app/classicpowermenu/components/xposed/Xposed.kt
+++ b/app/src/main/java/com/kieronquinn/app/classicpowermenu/components/xposed/Xposed.kt
@@ -59,11 +59,23 @@ class Xposed: IXposedHookLoadPackage, ServiceConnection {
 
     private fun hookSystemUI(lpparam: XC_LoadPackage.LoadPackageParam){
         when {
-            miuiVersion >= 816 -> hookAospSystemUI(lpparam)
+            miuiVersion >= 816 -> hookHyperOSSystemUI(lpparam)
             miuiVersion >= 125 -> hookMiuiSystemUI(lpparam)
             oneuiVersion >= 90000 -> hookOneUISystemUI(lpparam)
             else -> hookAospSystemUI(lpparam)
         }
+    }
+
+    private fun hookHyperOSSystemUI(lpparam: XC_LoadPackage.LoadPackageParam) {
+        XposedHelpers.findAndHookMethod("com.android.systemui.plugins.PluginEnablerImpl", lpparam.classLoader, "isEnabled", ComponentName::class.java, object: XC_MethodHook() {
+            override fun beforeHookedMethod(param: MethodHookParam) {
+                if (param.args[0].toString().contains("GlobalActions")) {
+                    param.result = false
+                }
+            }
+        })
+
+        hookAospSystemUI(lpparam)
     }
 
     private fun hookOneUISystemUI(lpparam: XC_LoadPackage.LoadPackageParam) {


### PR DESCRIPTION
This patch adds support for the Xposed hooking method on HyperOS.

It hooks PluginEnablerImpl to load the AOSP power menu instead of the HyperOS one, which then in turn allows the AOSP hooking method to work.